### PR TITLE
fix: MC-41 Display name errors were corrected

### DIFF
--- a/Web/WhitePage.MyWeb.UI/src/app/cases/cases-details/manage_case.component.html
+++ b/Web/WhitePage.MyWeb.UI/src/app/cases/cases-details/manage_case.component.html
@@ -78,7 +78,7 @@
 
             <div class="card">
                 <div class="card-header">
-                    Other Info (1)
+                    Other Info 
                 </div>
                 <div class="card-block">
 

--- a/Web/WhitePage.MyWeb.UI/src/app/cases/cases-routing.module.ts
+++ b/Web/WhitePage.MyWeb.UI/src/app/cases/cases-routing.module.ts
@@ -56,7 +56,7 @@ const routes: Routes = [
             component: CasesMoveComponent,
             canActivate: [AuthGuard],
             data: {
-                title: 'Manage Case'
+                title: 'Move Case'
             }
         },]
     }

--- a/Web/WhitePage.MyWeb.UI/src/app/cases/cases-view/case-management.component.html
+++ b/Web/WhitePage.MyWeb.UI/src/app/cases/cases-view/case-management.component.html
@@ -43,7 +43,7 @@
     <div class="col-md-6 d-flex flex-column">
         <div class="card">
             <div class="card-header">
-                Other Info (1)
+                Other Info
             </div>
             <div class="card-block info-view">
                 <div class="form-group">

--- a/Web/WhitePage.MyWeb.UI/src/app/cases/cases.create.html
+++ b/Web/WhitePage.MyWeb.UI/src/app/cases/cases.create.html
@@ -79,7 +79,7 @@
         <div class="col-md-4 d-flex flex-column">
             <div class="card flex-fill">
                 <div class="card-header">
-                    Client Details
+                    Client Address Details
                 </div>
                 <div class="card-block">
                     <div class="form-group">
@@ -139,7 +139,7 @@
         <div class="col-md-4 d-flex flex-column">
             <div class="card flex-fill">
                 <div class="card-header">
-                    Client Details (2)
+                    Client Personal Details
                 </div>
                 <div class="card-block">
                     <div class="form-group">

--- a/Web/WhitePage.MyWeb.UI/src/app/cases/cases.create.html
+++ b/Web/WhitePage.MyWeb.UI/src/app/cases/cases.create.html
@@ -139,7 +139,7 @@
         <div class="col-md-4 d-flex flex-column">
             <div class="card flex-fill">
                 <div class="card-header">
-                    Client Details(2)
+                    Client Details (2)
                 </div>
                 <div class="card-block">
                     <div class="form-group">

--- a/Web/WhitePage.MyWeb.UI/src/app/cases/cases.create.html
+++ b/Web/WhitePage.MyWeb.UI/src/app/cases/cases.create.html
@@ -139,7 +139,7 @@
         <div class="col-md-4 d-flex flex-column">
             <div class="card flex-fill">
                 <div class="card-header">
-                    Client Details
+                    Client Details(2)
                 </div>
                 <div class="card-block">
                     <div class="form-group">

--- a/Web/WhitePage.MyWeb.UI/src/app/cases/cases.list.ts
+++ b/Web/WhitePage.MyWeb.UI/src/app/cases/cases.list.ts
@@ -155,7 +155,7 @@ export class CasesListComponent implements OnInit {
     public rows: Array<any> = [];
     public columns: Array<any> = [
         { title: 'No#', name: 'CaseNumber', sort: true, filtering: { filterString: '', placeholder: 'No#' } },
-        { title: 'Name', name: 'ClientName', sort: true, filtering: { filterString: '', placeholder: 'Name#' } },
+        { title: 'Name', name: 'ClientName', sort: true, filtering: { filterString: '', placeholder: 'Name' } },
         { title: 'Status', name: 'CaseStatus', sort: true, filtering: { filterString: '', placeholder: 'Status' } },
         { title: 'Date', name: 'RegisterDateString', sort: true, filtering: { filterString: '', placeholder: 'Date' } },
         { title: 'Center', name: 'CenterTitle', sort: true, filtering: { filterString: '', placeholder: 'Center' } },


### PR DESCRIPTION
1 . Card Name in Create case was renamed.
2. The name field having extra # in its place holder in All Cases was removed
3. The heading in the move case page was renamed to Move case instead of current heading which is manage case.
4. The second card of the Case Management tab was Other Info(1) ,now changed to Other Info