### PR TITLE
Fix: MC-57 Position of Error Message in Sign-in page (client side)

### DIFF
--- a/Web/WhitePage.MyWeb.UI/src/app/pages/pages.signin.html
+++ b/Web/WhitePage.MyWeb.UI/src/app/pages/pages.signin.html
@@ -16,9 +16,9 @@
             </button>
             <button role="button" type="submit" tabindex="5"
                     value="Log In" (click)="tempSignIn()">Temp</button>
-            <div class="form-group">
-                <small class="mat-text-warn">{{errorMsg}}</small>
-            </div>
+        </div>
+        <div class="form-group signin-warning-message">
+            <small class="mat-text-warn">{{errorMsg}}</small>
         </div>
     </div>
 </div>

--- a/Web/WhitePage.MyWeb.UI/src/app/pages/signin.scss
+++ b/Web/WhitePage.MyWeb.UI/src/app/pages/signin.scss
@@ -2,3 +2,7 @@
     display: flex;
     justify-content: center
 }
+.signin-warning-message {
+    margin-top: 2%;
+    margin-left: 20%;
+}


### PR DESCRIPTION
Checked for different screen sizes and browsers
#Chrome

![chromeerror](https://user-images.githubusercontent.com/24319113/32979826-2aa4b70a-cc82-11e7-9454-f5cc5a2d6bc7.PNG)

#Edge
![edgeerror](https://user-images.githubusercontent.com/24319113/32979834-3df746c4-cc82-11e7-895a-9d1ed193132e.PNG)
