### PR TITLE
PeaceTracker : Fix: MC-157 Issues in the serial number generation

### DIFF
--- a/Common/WhitePage.Entities/CaseManagement/SerialNumberTracker.cs
+++ b/Common/WhitePage.Entities/CaseManagement/SerialNumberTracker.cs
@@ -9,7 +9,6 @@ namespace WhitePage.Entities.CaseManagement
     {
         [Key]
         public int SerialNumberTrackerId { get; set; }
-        public int SerialNumberId { get; set; }
         public int SerialValue { get; set; }        
         public DateTime GeneratedDate { get; set; }
     }

--- a/Database/WhitePage.MainDb/Core/Tables/trSerialNumberTracker.sql
+++ b/Database/WhitePage.MainDb/Core/Tables/trSerialNumberTracker.sql
@@ -1,7 +1,6 @@
 ﻿CREATE TABLE [Core].[trSerialNumberTracker]
 (
 	SerialNumberTrackerId INT primary key identity(1,1),
-	SerialNumberId int not null,
 	SerialValue INT NOT NULL,
 	GeneratedDate DateTime NOT NULL
 )

--- a/Infrastructure/WhitePage.ResourceAccess/Implementation/Ops/CaseDataAccess.cs
+++ b/Infrastructure/WhitePage.ResourceAccess/Implementation/Ops/CaseDataAccess.cs
@@ -25,21 +25,26 @@ namespace WhitePage.ResourceAccess.Implementation.Ops
         public CaseHeader SavePrimaryCase(CaseBook caseBook)
         {
             /*Case Number generation */
-            int maxSerialNumber = this.unitOfWork.DbContext.SerialNumberTracker.Max(serialNumber => serialNumber.SerialValue);
-            String padding = "0000";
-            String serialNumberComponent = padding.Remove(padding.Length - maxSerialNumber.ToString().Length) + (++maxSerialNumber).ToString();
-            DateTime generatedDate = DateTime.Now;
-            caseBook.Case.CaseNumber = generatedDate.Year.ToString().Substring(2) + generatedDate.Month.ToString()+'-'+ serialNumberComponent;
+            int newSerialNumber = this.unitOfWork.DbContext.SerialNumberTracker.Max(serialNumber => serialNumber.SerialValue) + 1 ;
+            String serialNumberPadding = "0000";
+            String serialNumberComponent = serialNumberPadding.Remove(serialNumberPadding.Length - newSerialNumber.ToString().Length) + (newSerialNumber).ToString();
+
+            DateTime generatedDate = DateTime.UtcNow.AddHours(5.5);
+            string monthPadding = "00";
+            String monthComponent = monthPadding.Remove(monthPadding.Length - generatedDate.Month.ToString().Length) + generatedDate.Month.ToString();
+            caseBook.Case.CaseNumber = generatedDate.Year.ToString().Substring(2) + monthComponent + '-'+ serialNumberComponent;
 
             Case caseObj;
             CaseHeader caseHeaderObj;
             CaseAddress caseAddressObj;
-            SerialNumberTracker serialNumberTrackerObj= new SerialNumberTracker();
 
             /*Initializing Serial Number Object*/
-            serialNumberTrackerObj.SerialNumberId = 1;
-            serialNumberTrackerObj.SerialValue = maxSerialNumber;
-            serialNumberTrackerObj.GeneratedDate = generatedDate;
+            SerialNumberTracker serialNumberTrackerObj = new SerialNumberTracker
+            {               
+                SerialNumberId = 1,
+                SerialValue = newSerialNumber,
+                GeneratedDate = generatedDate
+            };
 
             /*Serial Number entry*/
             this.unitOfWork.DbContext.SerialNumberTracker.Add(serialNumberTrackerObj);

--- a/Infrastructure/WhitePage.ResourceAccess/Implementation/Ops/CaseDataAccess.cs
+++ b/Infrastructure/WhitePage.ResourceAccess/Implementation/Ops/CaseDataAccess.cs
@@ -41,7 +41,6 @@ namespace WhitePage.ResourceAccess.Implementation.Ops
             /*Initializing Serial Number Object*/
             SerialNumberTracker serialNumberTrackerObj = new SerialNumberTracker
             {               
-                SerialNumberId = 1,
                 SerialValue = newSerialNumber,
                 GeneratedDate = generatedDate
             };

--- a/Infrastructure/WhitePage.ResourceAccess/Implementation/Ops/CaseDataAccess.cs
+++ b/Infrastructure/WhitePage.ResourceAccess/Implementation/Ops/CaseDataAccess.cs
@@ -26,12 +26,12 @@ namespace WhitePage.ResourceAccess.Implementation.Ops
         {
             /*Case Number generation */
             int newSerialNumber = this.unitOfWork.DbContext.SerialNumberTracker.Max(serialNumber => serialNumber.SerialValue) + 1 ;
-            String serialNumberPadding = "0000";
-            String serialNumberComponent = serialNumberPadding.Remove(serialNumberPadding.Length - newSerialNumber.ToString().Length) + (newSerialNumber).ToString();
+            string serialNumberPadding = "0000";
+            string serialNumberComponent = serialNumberPadding.Remove(serialNumberPadding.Length - newSerialNumber.ToString().Length) + newSerialNumber.ToString();
 
             DateTime generatedDate = DateTime.UtcNow.AddHours(5.5);
             string monthPadding = "00";
-            String monthComponent = monthPadding.Remove(monthPadding.Length - generatedDate.Month.ToString().Length) + generatedDate.Month.ToString();
+            string monthComponent = monthPadding.Remove(monthPadding.Length - generatedDate.Month.ToString().Length) + generatedDate.Month.ToString();
             caseBook.Case.CaseNumber = generatedDate.Year.ToString().Substring(2) + monthComponent + '-'+ serialNumberComponent;
 
             Case caseObj;


### PR DESCRIPTION

The month component of the Serial Number doesnt have padding , leading to generation of serial numbers of pattern YYM-SerialValue instead of YYMM-serialValue.

[SerialNumberTrackerScript.txt](https://github.com/rakeshrohan/MyChoices/files/1747111/SerialNumberTrackerScript.txt)