### PR TITLE
PeaceTracker: MC-158, MC-159 Issues with Legal data

### DIFF
--- a/Infrastructure/WhitePage.BusinessAccess/Implementation/Ops/CaseBusinessAccess.cs
+++ b/Infrastructure/WhitePage.BusinessAccess/Implementation/Ops/CaseBusinessAccess.cs
@@ -194,7 +194,7 @@ namespace WhitePage.BusinessAccess.Implementation.Ops
         {
             return (this.caseDataAccess.UpdateCaseManagement(caseBook) != 0) & (this.caseDataAccess.UpdateSpouse(caseBook) != 0) 
                  & (this.caseDataAccess.UpdatePhysicalHealth(caseBook) != 0) & (this.caseDataAccess.UpdateHouseHold(caseBook) != 0) 
-                 & (this.caseDataAccess.UpdateAbuse(caseBook) != 0);
+                 & (this.caseDataAccess.UpdateAbuse(caseBook) != 0) & (this.caseDataAccess.UpdateLegal(caseBook) != 0);
         }
         public bool DeleteCase(int caseId)
         {

--- a/Web/WhitePage.MyWeb.UI/Controllers/CasesController.cs
+++ b/Web/WhitePage.MyWeb.UI/Controllers/CasesController.cs
@@ -316,6 +316,9 @@ namespace WhitePage.MyWeb.UI.Controllers
             caseBook.Abuse.TypesOfEconomicAbuseLookupId = caseBook.Abuse.TypesOfEconomicAbuseLookupArray.ToArrayString();
             caseBook.Abuse.ReasonsForAbuseLookupId = caseBook.Abuse.ReasonsForAbuseLookupArray.ToArrayString();
 
+            caseBook.Legal.OutcomeLookupId = caseBook.Legal.OutcomeLookupArray.ToArrayString();
+            caseBook.Legal.DocumentsLookupId = caseBook.Legal.DocumentsLookupArray.ToArrayString();
+
             var updatedCase = this.caseBusinessAccess.UpdateCaseStatus(caseBook);
 
             return Ok(updatedCase);

--- a/Web/WhitePage.MyWeb.UI/src/app/cases/cases.move.html
+++ b/Web/WhitePage.MyWeb.UI/src/app/cases/cases.move.html
@@ -912,21 +912,15 @@
                             </div>
                             <div class="card-block">
                                 <div class="form-group">
-                                    <label for="CenterId">Outcome *</label>
+                                    <label for="CenterId">Outcome </label>
                                     <ss-multiselect-dropdown [options]="outcomeLookupOptionList" formControlName="OutcomeLookupId" [(ngModel)]="caseBook.Legal.OutcomeLookupArray">
                                     </ss-multiselect-dropdown>
-                                    <div>
-                                        <small *ngIf="category5Form.controls['OutcomeLookupId'].hasError('required') && category5Form.controls['OutcomeLookupId'].touched" class="mat-text-warn">Field is required.</small>
-                                    </div>
                                 </div>
 
                                 <div class="form-group">
                                     <label for="CenterId">List all documents that the client has submitted</label>
                                     <ss-multiselect-dropdown [options]="documentsLookupOptionList" formControlName="DocumentsLookupId" [(ngModel)]="caseBook.Legal.DocumentsLookupArray">
                                     </ss-multiselect-dropdown>
-                                    <div>
-                                        <small *ngIf="category5Form.controls['DocumentsLookupId'].hasError('required') && category5Form.controls['DocumentsLookupId'].touched" class="mat-text-warn">Field is required.</small>
-                                    </div>
                                 </div>
                             </div>
                         </div>

--- a/Web/WhitePage.MyWeb.UI/src/app/cases/cases.move.ts
+++ b/Web/WhitePage.MyWeb.UI/src/app/cases/cases.move.ts
@@ -398,8 +398,8 @@ export class CasesMoveComponent extends BaseCaseController implements OnInit, On
 
             LegalConsentFormLookupId: [this.caseBook.Legal.LegalConsentFormLookupId == undefined ? null : this.caseBook.Legal.LegalConsentFormLookupId.toString(), Validators.required],
             LegalActionLookupId: [this.caseBook.Legal.LegalActionLookupId == undefined ? null : this.caseBook.Legal.LegalActionLookupId.toString(), Validators.required],
-            OutcomeLookupId: [this.caseBook.Legal.OutcomeLookupId == undefined ? null : this.caseBook.Legal.OutcomeLookupId.toString(), Validators.required],
-            DocumentsLookupId: [this.caseBook.Legal.DocumentsLookupId == undefined ? null : this.caseBook.Legal.DocumentsLookupId.toString(), Validators.required]
+            OutcomeLookupId: [this.caseBook.Legal.OutcomeLookupId == undefined ? null : this.caseBook.Legal.OutcomeLookupId.toString()],
+            DocumentsLookupId: [this.caseBook.Legal.DocumentsLookupId == undefined ? null : this.caseBook.Legal.DocumentsLookupId.toString()]
         });
     }
 


### PR DESCRIPTION
-  Made the "Outcome" and "List all documents that the client has submitted" non-mandatory while moving a case. 
-  Fixed legal data storing issue while moving a case

The button is enabled when all the other fields except "Outcome" and "List all documents that the client has submitted" are filled 

![legal](https://user-images.githubusercontent.com/24319113/36383936-a40a3a6e-15b3-11e8-9abe-8c41dca9f81d.PNG)


