### PR TITLE
Fix: MC-185 MonthAndYearPicker Issues (RA:Mobile app)

### DIFF
--- a/NexGenRedAlert/NexGenRedAlert/Custom/CustomMonthYearPicker.cs
+++ b/NexGenRedAlert/NexGenRedAlert/Custom/CustomMonthYearPicker.cs
@@ -39,7 +39,7 @@ namespace NexGenRedAlert.Custom
         private void PopulateMonthAndYear()
         {
             // Populate Year
-            for (int i=2017; i<2100; i++)
+            for (int i=2018; i<2100; i++)
             {
                 Year.Add(i.ToString());
             }

--- a/NexGenRedAlert/NexGenRedAlert/Views/ProgrammePlanningFormPage.xaml
+++ b/NexGenRedAlert/NexGenRedAlert/Views/ProgrammePlanningFormPage.xaml
@@ -11,7 +11,7 @@
                 <StackLayout Margin="20,20,20,0" Spacing="10" VerticalOptions="StartAndExpand">
                     <Label x:Name="PlanningMonthLabel" Text="Planning Month and Year" FontSize="15" TextColor="{StaticResource PrimaryDark}"/>
 
-                    <Entry x:Name="PlanningMonthAndYearEntry" Placeholder="Choose month " Focused="OnPlanningMonthAndYearEntryFocused" Text="{ Binding ProgrammePlanningForm.PlanningMonthAndYear }" />
+                    <local:KeyboardDisabledEntry x:Name="PlanningMonthAndYearEntry" Placeholder="Choose Month and Year" Focused="OnPlanningMonthAndYearEntryFocused" Text="{ Binding ProgrammePlanningForm.PlanningMonthAndYear }" />
                     <local:CustomMonthYearPicker x:Name="PlanningMonthAndYearPicker" ColumnHeaderHeight="50" HeaderBackgroundColor="Black" IsVisible="False" HorizontalOptions="Center" PickerHeight="200" PickerMode="Dialog"  PickerWidth="300" />
 
                     <Label x:Name="VillageCodeLabel" Text="VillageCode:" FontSize="15" TextColor="{StaticResource PrimaryDark}"/>

--- a/NexGenRedAlert/NexGenRedAlert/Views/ProgrammePlanningFormPage.xaml.cs
+++ b/NexGenRedAlert/NexGenRedAlert/Views/ProgrammePlanningFormPage.xaml.cs
@@ -1,5 +1,6 @@
 ﻿using NexGenRedAlert.Models;
 using NexGenRedAlert.ViewModels;
+using Syncfusion.SfPicker.XForms;
 using System;
 using System.Collections;
 using System.Collections.Generic;
@@ -22,7 +23,7 @@ namespace NexGenRedAlert.Views
             ProgrammeTypeList.Add("SVP");
             ProgrammeTypeList.Add("Revisit");
             PlanningTypePicker.ItemsSource = ProgrammeTypeList;
-            PlanningMonthAndYearPicker.OkButtonClicked += Month_OkButtonClicked;
+            PlanningMonthAndYearPicker.OkButtonClicked += MonthAndYearPicker_OkButtonClicked;
         }
 
         public void OnPlanningMonthAndYearEntryFocused(object sender, EventArgs evt)
@@ -30,7 +31,7 @@ namespace NexGenRedAlert.Views
             PlanningMonthAndYearPicker.IsOpen = true;
         }
 
-        private void Month_OkButtonClicked(object sender, Syncfusion.SfPicker.XForms.SelectionChangedEventArgs e)
+        private void MonthAndYearPicker_OkButtonClicked(object sender, SelectionChangedEventArgs e)
         {
             string MonthAndYear = "";
             if (e.NewValue is IEnumerable selectedValue)
@@ -38,8 +39,9 @@ namespace NexGenRedAlert.Views
                 foreach (object element in selectedValue)
                     MonthAndYear += element + ", ";
             }
-            PlanningMonthAndYearEntry.Text = MonthAndYear.Remove(MonthAndYear.Length-2);
-            VillageCodeEntry.Focus();
+            if(!String.IsNullOrEmpty(MonthAndYear))
+                PlanningMonthAndYearEntry.Text = MonthAndYear.Remove(MonthAndYear.Length-2);
+            PlanningMonthAndYearEntry.Unfocus();
         }
 
         public async void OnUnfocusedVillageCodeEntryAsync(object sender, EventArgs evt)


### PR DESCRIPTION
NeXGen RedAlert Mobile app:

1. Disabled the Keyboard popping in the background while opening the MonthAndYear picker
2. Picker unfocusing.
3. Misc fixes (using Syncfusion.SfPicker.XForms, Naming conventions) 